### PR TITLE
Maintenance

### DIFF
--- a/ausseabed/mbesgc/lib/mbesgridcheck.py
+++ b/ausseabed/mbesgc/lib/mbesgridcheck.py
@@ -149,7 +149,7 @@ class DensityCheck(GridCheck):
             ogr_srs = osr.SpatialReference()
             ogr_srs.ImportFromWkt(ifd.projection)
 
-            ogr_driver = ogr.GetDriverByName('Memory')
+            ogr_driver = ogr.GetDriverByName('MEM')
             ogr_dataset = ogr_driver.CreateDataSource('shapemask')
             ogr_layer = ogr_dataset.CreateLayer('shapemask', srs=ogr_srs)
 
@@ -165,7 +165,7 @@ class DensityCheck(GridCheck):
                 callback=None
             )
 
-            ogr_simple_driver = ogr.GetDriverByName('Memory')
+            ogr_simple_driver = ogr.GetDriverByName('MEM')
             ogr_simple_dataset = ogr_simple_driver.CreateDataSource(
                 'failed_poly')
             ogr_simple_layer = ogr_simple_dataset.CreateLayer(
@@ -525,7 +525,7 @@ class TvuCheck(GridCheck):
             tile_failed_band.FlushCache()
             tile_failed_ds.SetProjection(ifd.projection)
 
-            ogr_driver = ogr.GetDriverByName('Memory')
+            ogr_driver = ogr.GetDriverByName('MEM')
             ogr_dataset = ogr_driver.CreateDataSource('shapemask')
             ogr_layer = ogr_dataset.CreateLayer('shapemask', srs=ogr_srs)
 
@@ -541,7 +541,7 @@ class TvuCheck(GridCheck):
                 callback=None
             )
 
-            ogr_simple_driver = ogr.GetDriverByName('Memory')
+            ogr_simple_driver = ogr.GetDriverByName('MEM')
             ogr_simple_dataset = ogr_simple_driver.CreateDataSource(
                 'failed_poly')
             ogr_simple_layer = ogr_simple_dataset.CreateLayer(
@@ -892,7 +892,7 @@ class ResolutionCheck(GridCheck):
             tile_failed_band.FlushCache()
             tile_failed_ds.SetProjection(ifd.projection)
 
-            ogr_driver = ogr.GetDriverByName('Memory')
+            ogr_driver = ogr.GetDriverByName('MEM')
             ogr_dataset = ogr_driver.CreateDataSource('shapemask')
             ogr_layer = ogr_dataset.CreateLayer('shapemask', srs=ogr_srs)
 
@@ -908,7 +908,7 @@ class ResolutionCheck(GridCheck):
                 callback=None
             )
 
-            ogr_simple_driver = ogr.GetDriverByName('Memory')
+            ogr_simple_driver = ogr.GetDriverByName('MEM')
             ogr_simple_dataset = ogr_simple_driver.CreateDataSource(
                 'failed_poly')
             ogr_simple_layer = ogr_simple_dataset.CreateLayer(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "ausseabed.mbesgc"
-version = "0.0.1"
+version = "0.1.0"
 description = "Quality Assurance checks for grid data derived from Multi Beam Echo Sounder data"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 
 authors = [
@@ -14,7 +14,7 @@ authors = [
 dependencies = [
   "ausseabed.qajson",
   "affine",
-  "Click",
+  "click",
   "numpy",
   "scipy",
   "gdal",


### PR DESCRIPTION
* Address GDAL warnings `Memory` -> `MEM`
* Bump version
* Bump minimal Python to 3.10