### PR TITLE
fix: correct param name in Density Check Excel export

### DIFF
--- a/ausseabed/mbesgc/qax/plugin.py
+++ b/ausseabed/mbesgc/qax/plugin.py
@@ -108,7 +108,7 @@ class MbesGridChecksQaxPlugin(QaxCheckToolPlugin):
                 (
                     p
                     for p in density_check.inputs.params
-                    if p.name == 'Minimum Soundings per node at percentage'
+                    if p.name == 'Minimum Soundings per node percentage'
                 ),
                 None
             )


### PR DESCRIPTION
## Summary

Fixed a typo in parameter name lookup that caused the Excel export to always show '% of nodes with 5 soundings or greater' regardless of the configured threshold.

**Root cause:** The code in  was looking for parameter name 'Minimum Soundings per node at percentage' but the actual parameter defined in  is named 'Minimum Soundings per node percentage'.

**Fix:** Changed line 111 in :
- Before: `p.name == 'Minimum Soundings per node at percentage'`
- After: `p.name == 'Minimum Soundings per node percentage'`

**Verification:**
- Python syntax check passed
- Diff: 1 line changed (+1/-1)
- No GH007 email leakage in commit

**Fixes #7**