### PR TITLE
fix: correct typo in parameter name node_at_percentage

### DIFF
--- a/ausseabed/mbesgc/qax/plugin.py
+++ b/ausseabed/mbesgc/qax/plugin.py
@@ -108,7 +108,7 @@ class MbesGridChecksQaxPlugin(QaxCheckToolPlugin):
                 (
                     p
                     for p in density_check.inputs.params
-                    if p.name == 'Minimum Soundings per node at percentage'
+                    if p.name == 'Minimum Soundings per node percentage'
                 ),
                 None
             )


### PR DESCRIPTION
fix: correct parameter name typo in qax/plugin.py

- Changed: `node_at_percentage` → `node_percentage` to match the definition in mbesgridcheck.py
- Only the reference in qax/plugin.py line 111 was fixed; the parameter definition in mbesgridcheck.py was not modified