### PR TITLE
fix(qax): align density parameter name with definition

### DIFF
--- a/ausseabed/mbesgc/qax/plugin.py
+++ b/ausseabed/mbesgc/qax/plugin.py
@@ -108,7 +108,7 @@ class MbesGridChecksQaxPlugin(QaxCheckToolPlugin):
                 (
                     p
                     for p in density_check.inputs.params
-                    if p.name == 'Minimum Soundings per node at percentage'
+                    if p.name == 'Minimum Soundings per node percentage'
                 ),
                 None
             )

--- a/tests/ausseabed/mbesgc/lib/test_data.py
+++ b/tests/ausseabed/mbesgc/lib/test_data.py
@@ -35,7 +35,7 @@ check01_str = """
                 "value": 5
             },
             {
-                "name": "Minimum Soundings per node at percentage",
+                "name": "Minimum Soundings per node percentage",
                 "value": 9
             },
             {
@@ -84,7 +84,7 @@ check02_str = """
                 "value": 5
             },
             {
-                "name": "Minimum Soundings per node at percentage",
+                "name": "Minimum Soundings per node percentage",
                 "value": 9
             },
             {

--- a/tests/ausseabed/mbesgc/lib/test_executor.py
+++ b/tests/ausseabed/mbesgc/lib/test_executor.py
@@ -36,7 +36,7 @@ check01_str = """
                 "value": 5
             },
             {
-                "name": "Minimum Soundings per node at percentage",
+                "name": "Minimum Soundings per node percentage",
                 "value": 9
             },
             {
@@ -85,7 +85,7 @@ check02_str = """
                 "value": 5
             },
             {
-                "name": "Minimum Soundings per node at percentage",
+                "name": "Minimum Soundings per node percentage",
                 "value": 9
             },
             {


### PR DESCRIPTION
## Summary

Closes #7. `ausseabed/mbesgc/qax/plugin.py:111` looked up the density check parameter by the name `"Minimum Soundings per node at percentage"`, but `ausseabed/mbesgc/lib/mbesgridcheck.py:33` defines it as `"Minimum Soundings per node percentage"` - extra `at` on the consumer side. The result the reporter showed: the QAX report always rendered "% of nodes with 5 soundings or greater" (the default), regardless of the user's actual configuration. Remove the spurious `at` so the lookup matches the canonical name.

## Why this matters

The reporter caught the divergence by hand. With the typo, `next((p for p in density_check.inputs.params if p.name == 'Minimum Soundings per node at percentage'), None)` always returned `None`, so `percentage_node_number` fell through to whatever default the report initializer used. End users who configured the check with a non-default sounding count (the reporter's screenshot showed 9 vs the default 5) saw their value silently dropped in the Excel export.

The canonical name is the one in `mbesgridcheck.py:33`, which is also the name `mbesgridcheck.py:44` uses internally and the name the `QajsonParam` test fixtures at `tests/ausseabed/mbesgc/lib/test_gridcheck_density.py:104,137` already use. The qax-plugin side and a couple of older test-data/executor fixtures were the only places carrying the `at` form.

## Changes

- `ausseabed/mbesgc/qax/plugin.py:111` - remove `at`. Lookup now matches the canonical parameter name.
- `tests/ausseabed/mbesgc/lib/test_data.py:38,87` - test fixtures realigned to the corrected name (otherwise these fixtures keep using the typo and pass for the wrong reason).
- `tests/ausseabed/mbesgc/lib/test_executor.py:39,88` - same.

No production-data or schema migration; the parameter name is a string key used at runtime to fetch a QajsonParam.

## How to test

- `python3 -c "import ast; ast.parse(open('ausseabed/mbesgc/qax/plugin.py').read())"` - clean.
- `grep -rn "Minimum Soundings per node at" --include="*.py" .` - empty (the typo is fully purged from the tree).
- The remaining matches for `Minimum Soundings per node percentage` (the canonical name) appear in 6 places across the production code and tests, all consistent.

Fixes #7

AI-assisted.
